### PR TITLE
buyer_id付与とshowページで状態付与

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -39,6 +39,9 @@ class PurchasesController < ApplicationController
         end
         @exp_month = @customer_card.exp_month.to_s
         @exp_year = @customer_card.exp_year.to_s.slice(2,3)
+        @item_buyer = Item.find(params[:id])
+        @item_buyer.update( buyer_id: current_user.id)
+
       else
       end
     else
@@ -75,3 +78,4 @@ class PurchasesController < ApplicationController
     @item = Item.find(params[:item_id])
   end
 end
+

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -67,13 +67,13 @@
           .item-main__box__pic-3__category
             .item-main__box__pic-3__category__kategory 商品の状態 
             .selctbox 
-              = f.select :status,[["新品、未使用", 1],["未使用に近い", 2],["目立った傷や汚れなし", 3],["やや傷や汚れあり", 4],["傷や汚れあり", 5],["全体的に状態が悪い", 6]], { include_blank: "選択してください"}
+              = f.select :status,[["新品、未使用", "新品、未使用"],["未使用に近い", "未使用に近い"],["目立った傷や汚れなし", "目立った傷や汚れなし"],["やや傷や汚れあり", "やや傷や汚れあり"],["傷や汚れあり", "傷や汚れあり"],["全体的に状態が悪い", "全体的に状態が悪い"]], { include_blank: "選択してください"}
         .item-main__box__pic-4
           .item-main__box__pic-4__haisounituite 配送料について
           .item-main__box__pic-4__hutan  
             .item-main__box__pic-4__hutan__bun 配送料に負担  
             .selctbox 
-              = f.select :cost,[["着払い(購入者負担)", 1],["送料込み(出品者負担)", 2]], { include_blank: "選択してください"}
+              = f.select :cost,[["着払い(購入者負担)", "着払い(購入者負担)"],["送料込み(出品者負担)", "送料込み(出品者負担)"]], { include_blank: "選択してください"}
           .item-main__box__pic-4__hutannnado  
             .item-main__box__pic-4__hutan__bun 発送元の地域 必須
             .selctbox 
@@ -81,7 +81,7 @@
           .item-main__box__pic-4__hutannnado  
             .item-main__box__pic-4__hutan__bun 発送までの日数 必須
             .selctbox 
-              = f.select :days,[["1~2日で発送", 1],["2~3日で発送", 2],["4~7日で発送", 3]], { include_blank: "選択してください"}
+              = f.select :days,[["1~2日で発送", "1~2日で発送"],["2~3日で発送", "2~3日で発送"],["4~7日で発送", "4~7日で発送"]], { include_blank: "選択してください"}
         .item-main__box__pic-5
           .item-main__box__pic-5__kakaku 価格（¥300〜9,999,999）
           .item-main__box__pic-5__price


### PR DESCRIPTION
# What
商品を購入した際に購入した商品がビューで非表示になる
プルダウンで選択された内容が詳細ページに反映される


#Why
購入したはずの商品が何度も表示されるのを直したかった
詳細ページでは詳細内容が数字で表されていたのを解消したかった
